### PR TITLE
[fix] Force strict mode and empty ca

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -43,7 +43,8 @@ function setupNpmrc(subdomain, callback) {
   // Start setting correct values
   //
   npmrc['always-auth'] = true;
-  npmrc['strict-ssl'] = false;
+  npmrc['strict-ssl'] = true;
+  npmrc['ca'] = '';
   npmrc['registry'] = registryUrl.replace('<replace>', subdomain);
 
   noAuth = !npmrc['_auth'];


### PR DESCRIPTION
Updated the suggest setup information with the changes for the new HTTPS certificate:

http://blog.nodejitsu.com/improved-ssl-experience-for-private-npm/
